### PR TITLE
Remove hardcoded ffi extension

### DIFF
--- a/lib/resty/maxminddb.lua
+++ b/lib/resty/maxminddb.lua
@@ -149,7 +149,7 @@ local MMDB_DATA_TYPE_BOOLEAN                        =   14
 local MMDB_DATA_TYPE_FLOAT                          =   15
 
 -- you should install the libmaxminddb to your system
-local maxm                                          = ffi.load('libmaxminddb.so')
+local maxm                                          = ffi.load('libmaxminddb')
 local mmdb                                          = ffi_new('MMDB_s')
 local initted                                       = false
 --https://github.com/maxmind/libmaxminddb


### PR DESCRIPTION
`ffi.load` will automatically workout what extension it needs to put on files http://luajit.org/ext_ffi_api.html

This means you can use it on OSX for example.