### PR TITLE
pass Lua string directly instead of creating a new copy.

### DIFF
--- a/lib/resty/maxminddb.lua
+++ b/lib/resty/maxminddb.lua
@@ -157,8 +157,7 @@ local initted                                       = false
 function _M.init(dbfile)
   if not initted then
     initted = true
-    local file_name_ip2   = ffi_new('char[?]',#dbfile,dbfile)
-    local maxmind_ready   = maxm.MMDB_open(file_name_ip2,0,mmdb)
+    local maxmind_ready   = maxm.MMDB_open(dbfile,0,mmdb)
   end
   return initted
 end
@@ -304,11 +303,10 @@ function _M.lookup(ip)
       return nil, "not initialized"
   end
   
-  local ip_str = ffi_cast('const char *',ffi_new('char[?]',#ip+1,ip))
   local gai_error = ffi_new('int[1]')
   local mmdb_error = ffi_new('int[1]')
 
-  local result = maxm.MMDB_lookup_string(mmdb,ip_str,gai_error,mmdb_error)
+  local result = maxm.MMDB_lookup_string(mmdb,ip,gai_error,mmdb_error)
 
   if mmdb_error[0] ~= MMDB_SUCCESS then
     return nil,'fail when lookup'


### PR DESCRIPTION
The Lua string is null terminated, and LuaJIT will handle the type cast
from Lua string to 'const char *' C string automatically.