### PR TITLE
Fix Boolean datatype

### DIFF
--- a/lib/resty/maxminddb.lua
+++ b/lib/resty/maxminddb.lua
@@ -287,7 +287,7 @@ local function _dump_entry_data_list(entry_data_list,status)
     elseif data_type == MMDB_DATA_TYPE_UINT32 then
       val = entry_data_item.uint32
     elseif data_type == MMDB_DATA_TYPE_BOOLEAN then
-      val = entry_data_item.boolean == 1
+      val = entry_data_item.boolean
     elseif data_type == MMDB_DATA_TYPE_UINT64 then
       val = entry_data_item.uint64
     elseif data_type == MMDB_DATA_TYPE_INT32 then


### PR DESCRIPTION
So the Lua FFI seems to already take care of converting C `bool` to a Lua `boolean`. Comparing it with 1 means that Boolean values always end up `false`.

Just remove the comparison and this fixes it.

Fixes #19