### PR TITLE
Prevent occasional SEGV when freeing list

### DIFF
--- a/lib/resty/maxminddb.lua
+++ b/lib/resty/maxminddb.lua
@@ -335,8 +335,9 @@ function _M.lookup(ip)
     return nil,'get entry data failed: ' .. mmdb_strerror(status)
   end  
   
+  local head = entry_data_list[0] -- Save so this can be passed to free fn.
   local _,status,result = _dump_entry_data_list(entry_data_list)
-  maxm.MMDB_free_entry_data_list(entry_data_list[0])
+  maxm.MMDB_free_entry_data_list(head)
   
   if status ~= MMDB_SUCCESS then
     return nil,'dump entry data failed: ' .. mmdb_strerror(status)


### PR DESCRIPTION
The maxminddb API seems to need a pointer to the first element when passing to `MMDB_free_entry_data_list`. Observed occasional SEGVs under heavy load without this fix.

We just save a the head of the list before dumping and pass that to `MMDB_free_entry_data_list`.

Note this is the same way they do it in the C API:

https://github.com/maxmind/libmaxminddb/blob/fc183662e85cb1b252c2f0272dc41f79e52e50fa/src/maxminddb.c#L730.

CC #8, #9